### PR TITLE
feat: add type signature for toJSON() in handle

### DIFF
--- a/src/__tests__/handle.test.ts
+++ b/src/__tests__/handle.test.ts
@@ -230,4 +230,20 @@ describe("handle", () => {
       expect(payload).toBe("Oh no");
     });
   });
+
+  describe("handling object with toJSON() function", () => {
+    it("should return the same value as object with toJSON()", async () => {
+      const obj: any = { foo: "bar", baz: null, uwu: 123 };
+
+      const response1 = await createTestResponse([handle(() => obj)]);
+      const response2 = await createTestResponse([
+        handle(() => ({ toJSON: () => obj })),
+      ]);
+
+      expect(response1.headers).toEqual(response2.headers);
+      expect(JSON.parse(response1.payload)).toEqual(
+        JSON.parse(response2.payload)
+      );
+    });
+  });
 });

--- a/src/handle.ts
+++ b/src/handle.ts
@@ -1,10 +1,12 @@
 import { Request, Response, RequestHandler } from "express";
 import { ApiError } from "./api";
 
+type HandleValue<T> = T | { toJSON(): T };
+
 type HandleFunction<T = void> = (ctx: {
   req: Request;
   res: Response;
-}) => T | Promise<T>;
+}) => HandleValue<T> | Promise<HandleValue<T>>;
 
 export function handle<T = void>(fn: HandleFunction<T>): RequestHandler {
   return (req, res, next) =>


### PR DESCRIPTION
Make `handle` accepts objects with matching `toJSON()` value.

Closes #1 